### PR TITLE
Issue fix

### DIFF
--- a/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq-item/default/preview.html
+++ b/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq-item/default/preview.html
@@ -2,7 +2,9 @@
     <render args="getOptions().template" />
     <h3 data-bind="liveEdit: { field: 'question', placeholder: 'Edit question' }" data-role="collapsible"></h3>
     <div data-role="content">
-        <div if="isWysiwygSupported()" class="inline-wysiwyg" ko-style="data.answer.style" css="data.answer.css" attr="data.answer.attributes" afterRender="initWysiwyg"/>
+        <div if="isWysiwygSupported()" class="inline-wysiwyg" ko-style="data.answer.style" css="data.answer.css" attr="data.answer.attributes" afterRender="initWysiwyg">
+            <div html="data.answer.html" />
+        </div>
         <div if="isWysiwygSupported()" class="placeholder-text" ifnot="data.answer.html" translate="'Edit answer here.'"></div>
         <div ifnot="isWysiwygSupported()">
         <textarea class="inline-wysiwyg-textarea"


### PR DESCRIPTION
### Steps to reproduce

In Admin:

1. Go to a CMS page. Add a "FAQ" element to the page
2. Add a question
3. Add an answer text to a WYSIWYG field
4. Save the page
5. Observe the FAQ content

**Expected result:** 
the question text is visible. The answer text is visible by default (no need to go to the settings slideout panel of the FAQ item)

**Actual result:** 
the answer text is not visible by default. It can be edited only in the settings slideout panel of the FAQ item