### PR TITLE
Fixing css code duplication

### DIFF
--- a/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq-item/_import.less
+++ b/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq-item/_import.less
@@ -2,33 +2,35 @@
 //  FAQ item styles
 //  _____________________________________________
 
-[data-content-type="faq-item"] {
-    border-top: 1px solid #cccccc !important;
-    border-right: 1px solid #cccccc !important;
-    border-left: 1px solid #cccccc !important;
-    overflow: hidden;
+& when (@media-common = true) {
+    [data-content-type="faq-item"] {
+        border-top: 1px solid #cccccc !important;
+        border-right: 1px solid #cccccc !important;
+        border-left: 1px solid #cccccc !important;
+        overflow: hidden;
 
-    [data-role="collapsible"] {
-        font-weight: bold;
-        line-height: 1.1;
-        font-size: 1.4rem;
-        margin-top: 2rem;
-        margin-bottom: 2rem;
+        [data-role="collapsible"] {
+            font-weight: bold;
+            line-height: 1.1;
+            font-size: 1.4rem;
+            margin-top: 2rem;
+            margin-bottom: 2rem;
 
-        &:before {
-            font-family: @icons-pagebuilder__font-name;
-            margin-right: 5px;
-            font-size: 12px;
-            left: 15px;
-            position: absolute;
-        }
+            &:before {
+                font-family: @icons-pagebuilder__font-name;
+                margin-right: 5px;
+                font-size: 12px;
+                left: 15px;
+                position: absolute;
+            }
 
-        &[aria-expanded="true"]:before {
-            content: @icon-pagebuilder-caret-up__content;
-        }
+            &[aria-expanded="true"]:before {
+                content: @icon-pagebuilder-caret-up__content;
+            }
 
-        &[aria-expanded="false"]:before {
-            content: @icon-pagebuilder-caret-down__content;
+            &[aria-expanded="false"]:before {
+                content: @icon-pagebuilder-caret-down__content;
+            }
         }
     }
 }


### PR DESCRIPTION
Front end styles should be under `& when (@media-common = true) {}` mixin to avoid code duplication both in styles-m.css and styles-l.css