### PR TITLE
Magento 2.4.2 slider extension compatible

### DIFF
--- a/Slider/Extension/view/adminhtml/ui_component/pagebuilder_slide_form.xml
+++ b/Slider/Extension/view/adminhtml/ui_component/pagebuilder_slide_form.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <fieldset name="advanced">
         <field name="margins_and_padding">
             <argument name="data" xsi:type="array">


### PR DESCRIPTION
Magento 2.3.6 changed the slide form to be 'pagebuilder_base_form_with_background_video', need to update the slide form to make it work in 2.4.2