### PR TITLE
Replaces old background_attribute references with background_video form references.

### DIFF
--- a/Button/Extension/view/adminhtml/ui_component/pagebuilder_banner_form.xml
+++ b/Button/Extension/view/adminhtml/ui_component/pagebuilder_banner_form.xml
@@ -6,7 +6,7 @@
  */
 -->
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd"
-      extends="pagebuilder_base_form_with_background_attributes">
+      extends="pagebuilder_base_form_with_background_video">
     <fieldset name="contents">
         <field name="button_type" formElement="select">
             <formElements>

--- a/Button/Extension/view/adminhtml/ui_component/pagebuilder_slide_form.xml
+++ b/Button/Extension/view/adminhtml/ui_component/pagebuilder_slide_form.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <fieldset name="general">
         <!-- Integrate Hollow button style from theme -->
         <field name="button_type" formElement="select">

--- a/Forms/Extension/README.md
+++ b/Forms/Extension/README.md
@@ -1,12 +1,16 @@
 # PageBuilder- Base Form Extensions
 
-This example module shows you how to remove fields and fieldsets from Page Builder's built-in forms. Page Builder uses two forms to provide fieldsets and fields to all its content types:
+This example module shows you how to remove fields and fieldsets from Page Builder's built-in forms. Page Builder uses three forms to provide fieldsets and fields to all its content types:
 
 *  `Magento/PageBuilder/view/adminhtml/ui_component/pagebuilder_base_form.xml`
 *  `Magento/PageBuilder/view/adminhtml/ui_component/pagebuilder_base_form_with_background_attributes.xml`
+*  `Magento/PageBuilder/view/adminhtml/ui_component/pagebuilder_base_form_with_background_video.xml`
 
 The `pagebuilder_base_form.xml` provides the Advanced fieldset and all its fields (such as alignments, borders, margins and paddings).
-The `pagebuilder_base_form_with_background_attributes.xml` provides the Background fieldset and all its fields (such as background images, sizes, and positions).
+
+The `pagebuilder_base_form_with_background_attributes.xml` form inherits from the `pagebuilder_base_form` and adds the Background fieldset with all its fields (such as background images, sizes, and positions).
+
+Finally, the `pagebuilder_base_form_with_background_video.xml` form inherits from the `pagebuilder_base_form_with_background_attributes` and adds the Background Video fieldset with all its fields (such as video sources, sizes, and positions).
 
 As this example shows, you can _globally_ remove the fields or fieldsets from these base forms by adding same-named XML files to your module. Within these files, you simply add the field or fieldset you want to remove by nesting the `componentDisabled` setting. For example, to remove the border radius field:
 

--- a/Grid/Custom/view/adminhtml/ui_component/pagebuilder_homepage_grid_form.xml
+++ b/Grid/Custom/view/adminhtml/ui_component/pagebuilder_homepage_grid_form.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
             <item name="provider" xsi:type="string">pagebuilder_homepage_grid_form.pagebuilder_homepage_grid_form_data_source</item>

--- a/Grid/Custom/view/adminhtml/ui_component/pagebuilder_homepage_grid_item_form.xml
+++ b/Grid/Custom/view/adminhtml/ui_component/pagebuilder_homepage_grid_item_form.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
             <item name="provider" xsi:type="string">pagebuilder_homepage_grid_item_form.pagebuilder_homepage_grid_item_form_data_source</item>

--- a/Quote/Custom/view/adminhtml/ui_component/pagebuilder_custom_quote_form.xml
+++ b/Quote/Custom/view/adminhtml/ui_component/pagebuilder_custom_quote_form.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <argument name="data" xsi:type="array">
         <item name="js_config" xsi:type="array">
             <item name="provider" xsi:type="string">pagebuilder_Quote_Custom_form.pagebuilder_Quote_Custom_form_data_source</item>

--- a/ThemeKit/Deprecated/view/adminhtml/ui_component/pagebuilder_banner_form.xml
+++ b/ThemeKit/Deprecated/view/adminhtml/ui_component/pagebuilder_banner_form.xml
@@ -6,7 +6,7 @@
  */
 -->
 <form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd"
-      extends="pagebuilder_base_form_with_background_attributes">
+      extends="pagebuilder_base_form_with_background_video">
     <fieldset name="contents" sortOrder="30">
         <field name="button_type" formElement="select">
             <formElements>
@@ -36,4 +36,3 @@
         </field>
     </fieldset>
 </form>
-

--- a/ThemeKit/Deprecated/view/adminhtml/ui_component/pagebuilder_slide_form.xml
+++ b/ThemeKit/Deprecated/view/adminhtml/ui_component/pagebuilder_slide_form.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_attributes">
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd" extends="pagebuilder_base_form_with_background_video">
     <fieldset name="general">
 
         <!-- Integrate Color palette from theme -->


### PR DESCRIPTION
This PR updates the content type forms in the examples to match the latest content type forms used in Page Builder. The introduction of the `pagebuilder_base_form_with_background_video.xml`form in later versions of Page Builder superseded content type references to the `pagebuilder_base_form_with_background_attributes.xml` form. The new `background_video` form inherits from the `background_attributes` form, meaning that no functionality is lost. Rather, many content types can show videos in their backgrounds. Now the content type forms in the examples are synced with the latest forms in Page Builder 1.7.