### PR TITLE
Fixing 'Theme/Admin' error

### DIFF
--- a/Columns/Extension/etc/di.xml
+++ b/Columns/Extension/etc/di.xml
@@ -18,7 +18,7 @@ to the custom breakpoint property: columnsPerRow.
     <type name="Magento\Theme\Model\View\Design">
         <arguments>
             <argument name="themes" xsi:type="array">
-                <item name="adminhtml" xsi:type="string">Theme/Admin</item>
+                <item name="adminhtml" xsi:type="string">Magento/Backend</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
"Exception #0 (LogicException): Unable to load theme by specified key: error is generated due to 'Theme/Admin' value in <themes> tag.