### PR TITLE
Updated repo org

### DIFF
--- a/Columns/Extension/README.md
+++ b/Columns/Extension/README.md
@@ -4,7 +4,7 @@ This module provides an example that shows how to use breakpoints to control the
 
 ## Installation
 
-These steps assume you have already cloned the `pagebuilder-examples` repo to the root of your Magento instance, as described in [Installing the example modules](https://github.com/magento-devdocs/pagebuilder-examples/blob/master/README.md#installing-the-example-modules):
+These steps assume you have already cloned the `pagebuilder-examples` repo to the root of your Magento instance, as described in [Installing the example modules](https://github.com/commerce-docs/pagebuilder-examples/blob/master/README.md#installing-the-example-modules):
 
 1. Navigate to to the `app/code/` directory and create a symlink using the following command:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The best way to explore and use these example modules in Page Builder is to clon
 1. Clone this repo (`pagebuilder-examples`) to the root of your Magento instance:
 
     ```bash
-    git clone https://github.com/magento-devdocs/pagebuilder-examples.git
+    git clone https://github.com/commerce-docs/pagebuilder-examples.git
     ```
 
 1. Navigate to the `app/code/` directory (or create one as needed), then use the symlink command to add one or more of the example modules you want to add to your instance. For example, to install the `Columns` module, use the following command from within the `app/code/` directory:


### PR DESCRIPTION
After changing the org name to `commerce-docs`, we need to update references to repos since we no longer own the magento-devdocs org. That presents a security issue.